### PR TITLE
Equality check error meant reloading data from cache

### DIFF
--- a/src/main/groovy/com/fizzpod/ibroadcast/functions/TrackData.groovy
+++ b/src/main/groovy/com/fizzpod/ibroadcast/functions/TrackData.groovy
@@ -21,7 +21,7 @@ public class TrackData {
     public static final def read(File trackFile) {
         info("reading {}", trackFile)
         def track = cache.get(trackFile.getAbsolutePath())
-        if(track != null && trackFile.lastModified() != track.modified) {
+        if(track != null && trackFile.lastModified() == track.modified) {
             info("Loaded track from cache {}", track)
         } else {
             track = [:]


### PR DESCRIPTION
Bug in equality check meant that it was disregarding cached data and re-parsing tracks