### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -2,10 +2,10 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.21=runtimeClasspath,testRuntimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.21.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.21.2=runtimeClasspath,testRuntimeClasspath
-com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.2=runtimeClasspath,testRuntimeClasspath
-com.fasterxml.jackson:jackson-bom:2.21.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.21.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.21.3=runtimeClasspath,testRuntimeClasspath
+com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3=runtimeClasspath,testRuntimeClasspath
+com.fasterxml.jackson:jackson-bom:2.21.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.javaparser:javaparser-core:3.28.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.9.8=spotbugs
 com.github.spotbugs:spotbugs:4.9.8=spotbugs


### PR DESCRIPTION
Resolved build failure caused by Dependabot updating `jackson-core` but failing to update the `gradle.lockfile`. Ran `./gradlew --write-locks resolveAndLockAll` to fix this discrepancy and update the lockfile constraints for `jackson-core`, `jackson-databind`, `jackson-dataformat-yaml`, and `jackson-bom` to `2.21.3`. Verified tests and build pass locally.

---
*PR created automatically by Jules for task [2831242412913489959](https://jules.google.com/task/2831242412913489959) started by @boxheed*